### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 px4_add_module(
 	MODULE drivers__pixycam
 	MAIN pixycam
-	COMPILE_FLAGS
+	COMPILE_FLAGS -Wno-error=cast-align
 	STACK_MAIN 5000
 	SRCS
 		pixycam.cpp


### PR DESCRIPTION
Fixed error: cast from 'uint8_t* {aka unsigned char*}' to 'Version*' increases required alignment of target type [-Werror=cast-align]
    version = (Version *)m_buf;
              ^~~~~~~~~~~~~~~~